### PR TITLE
BZ1291 HttpError packet parsing fix

### DIFF
--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -108,9 +108,9 @@ request(Socket, Body, Prev) ->
                 {ok, {http_request, Method, Path, Version}, <<>>} ->
                     collect_headers(Socket, {Method, Path, Version}, Body,
                                     <<>>, false, 0);
-                {error, {http_error, "\r\n"}} ->
+                {ok, {http_error, "\r\n"}, <<>>} ->
                     request(Socket, Body, <<>>);
-                {error, {http_error, "\n"}} ->
+                {ok, {http_error, "\n"}, <<>>} ->
                     request(Socket, Body, <<>>);
                 {more, _} ->
                     request(Socket, Body, FullBin)


### PR DESCRIPTION
On the 1.5.1-headers-fix tag/branch, mochiweb_http uses erlang:decode_packet/3 but improperly matches HttpError packets as tagged with 'error', when the parser returns them tagged with 'ok'. This pull-request adjusts the case clause to match them properly.
