### PR TITLE
erlang:now() -> os:timestamp

### DIFF
--- a/src/mochiweb_acceptor.erl
+++ b/src/mochiweb_acceptor.erl
@@ -14,10 +14,11 @@ start_link(Server, Listen, Loop) ->
     proc_lib:spawn_link(?MODULE, init, [Server, Listen, Loop]).
 
 init(Server, Listen, Loop) ->
-    T1 = now(),
+    T1 = os:timestamp(),
     case catch mochiweb_socket:accept(Listen) of
         {ok, Socket} ->
-            gen_server:cast(Server, {accepted, self(), timer:now_diff(now(), T1)}),
+            gen_server:cast(Server, {accepted, self(),
+              timer:now_diff(os:timestamp(), T1)}),
             call_loop(Loop, Socket);
         {error, closed} ->
             exit(normal);


### PR DESCRIPTION
We don't need to use an expensive monotonic clock for calcuating timing
information.

This PR is against a new '1.5' branch, so we can patch the version of mochiweb webmachine depends on, master is much too new. The 1.5 branch was created from the latest 1.5.1 tag (1.5.1-riak-1.0.x-fixes).

Once this PR merges, webmachine's dependancies should be updated to reflect the change.
