### PR TITLE
Remove parameterized modules.

### DIFF
--- a/src/mochifmt_records.erl
+++ b/src/mochifmt_records.erl
@@ -9,11 +9,14 @@
 %%    M:format("{0.bar}", [#rec{bar=foo}]).
 %%    foo
 
--module(mochifmt_records, [Recs]).
+-module(mochifmt_records).
 -author('bob@mochimedia.com').
--export([get_value/2]).
+-export([new/1, get_value/3]).
 
-get_value(Key, Rec) when is_tuple(Rec) and is_atom(element(1, Rec)) ->
+new([{_Rec, RecFields}]=Recs) when is_list(RecFields) ->
+    {?MODULE, Recs}.
+
+get_value(Key, Rec, {?MODULE, Recs}) when is_tuple(Rec) and is_atom(element(1, Rec)) ->
     try begin
             Atom = list_to_existing_atom(Key),
             {_, Fields} = proplists:lookup(element(1, Rec), Recs),
@@ -21,7 +24,7 @@ get_value(Key, Rec) when is_tuple(Rec) and is_atom(element(1, Rec)) ->
         end
     catch error:_ -> mochifmt:get_value(Key, Rec)
     end;
-get_value(Key, Args) ->
+get_value(Key, Args, {?MODULE, _Recs}) ->
     mochifmt:get_value(Key, Args).
 
 get_rec_index(Atom, [Atom | _], Index) ->

--- a/src/mochifmt_std.erl
+++ b/src/mochifmt_std.erl
@@ -3,23 +3,26 @@
 
 %% @doc Template module for a mochifmt formatter.
 
--module(mochifmt_std, []).
+-module(mochifmt_std).
 -author('bob@mochimedia.com').
--export([format/2, get_value/2, format_field/2, get_field/2, convert_field/2]).
+-export([new/0, format/3, get_value/3, format_field/3, get_field/3, convert_field/3]).
 
-format(Format, Args) ->
+new() ->
+    {?MODULE}.
+
+format(Format, Args, {?MODULE}=THIS) ->
     mochifmt:format(Format, Args, THIS).
 
-get_field(Key, Args) ->
+get_field(Key, Args, {?MODULE}=THIS) ->
     mochifmt:get_field(Key, Args, THIS).
 
-convert_field(Key, Args) ->
+convert_field(Key, Args, {?MODULE}) ->
     mochifmt:convert_field(Key, Args).
 
-get_value(Key, Args) ->
+get_value(Key, Args, {?MODULE}) ->
     mochifmt:get_value(Key, Args).
 
-format_field(Arg, Format) ->
+format_field(Arg, Format, {?MODULE}=THIS) ->
     mochifmt:format_field(Arg, Format, THIS).
 
 %%

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -3,7 +3,7 @@
 
 %% @doc MochiWeb HTTP Request abstraction.
 
--module(mochiweb_request, [Socket, Method, RawPath, Version, Headers]).
+-module(mochiweb_request).
 -author('bob@mochimedia.com').
 
 -include_lib("kernel/include/file.hrl").
@@ -11,17 +11,18 @@
 
 -define(QUIP, "Any of you quaids got a smint?").
 
--export([get_header_value/1, get_primary_header_value/1, get/1, dump/0]).
--export([send/1, recv/1, recv/2, recv_body/0, recv_body/1, stream_body/3]).
--export([start_response/1, start_response_length/1, start_raw_response/1]).
--export([respond/1, ok/1]).
--export([not_found/0, not_found/1]).
--export([parse_post/0, parse_qs/0]).
--export([should_close/0, cleanup/0]).
--export([parse_cookie/0, get_cookie_value/1]).
--export([serve_file/2, serve_file/3]).
--export([accepted_encodings/1]).
--export([accepts_content_type/1]).
+-export([new/5]).
+-export([get_header_value/2, get_primary_header_value/2, get/2, dump/1]).
+-export([send/2, recv/2, recv/3, recv_body/1, recv_body/2, stream_body/4]).
+-export([start_response/2, start_response_length/2, start_raw_response/2]).
+-export([respond/2, ok/2]).
+-export([not_found/1, not_found/2]).
+-export([parse_post/1, parse_qs/1]).
+-export([should_close/1, cleanup/1]).
+-export([parse_cookie/1, get_cookie_value/2]).
+-export([serve_file/3, serve_file/4]).
+-export([accepted_encodings/2]).
+-export([accepts_content_type/2]).
 
 -define(SAVE_QS, mochiweb_request_qs).
 -define(SAVE_PATH, mochiweb_request_path).
@@ -37,6 +38,7 @@
 %% @type key() = atom() | string() | binary()
 %% @type value() = atom() | string() | binary() | integer()
 %% @type headers(). A mochiweb_headers structure.
+%% @type request(). A mochiweb_request parameterized module instance.
 %% @type response(). A mochiweb_response parameterized module instance.
 %% @type ioheaders() = headers() | [{key(), value()}].
 
@@ -46,50 +48,55 @@
 % Maximum recv_body() length of 1MB
 -define(MAX_RECV_BODY, (1024*1024)).
 
-%% @spec get_header_value(K) -> undefined | Value
+%% @spec new(Socket, Method, RawPath, Version, headers()) -> request()
+%% @doc Create a new request instance.
+new(Socket, Method, RawPath, Version, Headers) ->
+    {?MODULE, [Socket, Method, RawPath, Version, Headers]}.
+
+%% @spec get_header_value(K, request()) -> undefined | Value
 %% @doc Get the value of a given request header.
-get_header_value(K) ->
+get_header_value(K, {?MODULE, [_Socket, _Method, _RawPath, _Version, Headers]}) ->
     mochiweb_headers:get_value(K, Headers).
 
-get_primary_header_value(K) ->
+get_primary_header_value(K, {?MODULE, [_Socket, _Method, _RawPath, _Version, Headers]}) ->
     mochiweb_headers:get_primary_value(K, Headers).
 
 %% @type field() = socket | scheme | method | raw_path | version | headers | peer | path | body_length | range
 
-%% @spec get(field()) -> term()
+%% @spec get(field(), request()) -> term()
 %% @doc Return the internal representation of the given field. If
 %%      <code>socket</code> is requested on a HTTPS connection, then
 %%      an ssl socket will be returned as <code>{ssl, SslSocket}</code>.
 %%      You can use <code>SslSocket</code> with the <code>ssl</code>
 %%      application, eg: <code>ssl:peercert(SslSocket)</code>.
-get(socket) ->
+get(socket, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     Socket;
-get(scheme) ->
+get(scheme, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     case mochiweb_socket:type(Socket) of
         plain ->
             http;
         ssl ->
             https
     end;
-get(method) ->
+get(method, {?MODULE, [_Socket, Method, _RawPath, _Version, _Headers]}) ->
     Method;
-get(raw_path) ->
+get(raw_path, {?MODULE, [_Socket, _Method, RawPath, _Version, _Headers]}) ->
     RawPath;
-get(version) ->
+get(version, {?MODULE, [_Socket, _Method, _RawPath, Version, _Headers]}) ->
     Version;
-get(headers) ->
+get(headers, {?MODULE, [_Socket, _Method, _RawPath, _Version, Headers]}) ->
     Headers;
-get(peer) ->
+get(peer, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case mochiweb_socket:peername(Socket) of
         {ok, {Addr={10, _, _, _}, _Port}} ->
-            case get_header_value("x-forwarded-for") of
+            case get_header_value("x-forwarded-for", THIS) of
                 undefined ->
                     inet_parse:ntoa(Addr);
                 Hosts ->
                     string:strip(lists:last(string:tokens(Hosts, ",")))
             end;
         {ok, {{127, 0, 0, 1}, _Port}} ->
-            case get_header_value("x-forwarded-for") of
+            case get_header_value("x-forwarded-for", THIS) of
                 undefined ->
                     "127.0.0.1";
                 Hosts ->
@@ -100,7 +107,7 @@ get(peer) ->
         {error, enotconn} ->
             exit(normal)
     end;
-get(path) ->
+get(path, {?MODULE, [_Socket, _Method, RawPath, _Version, _Headers]}) ->
     case erlang:get(?SAVE_PATH) of
         undefined ->
             {Path0, _, _} = mochiweb_util:urlsplit_path(RawPath),
@@ -110,35 +117,35 @@ get(path) ->
         Cached ->
             Cached
     end;
-get(body_length) ->
+get(body_length, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case erlang:get(?SAVE_BODY_LENGTH) of
         undefined ->
-            BodyLength = body_length(),
+            BodyLength = body_length(THIS),
             put(?SAVE_BODY_LENGTH, {cached, BodyLength}),
             BodyLength;
         {cached, Cached} ->
             Cached
     end;
-get(range) ->
-    case get_header_value(range) of
+get(range, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    case get_header_value(range, THIS) of
         undefined ->
             undefined;
         RawRange ->
             mochiweb_http:parse_range_request(RawRange)
     end.
 
-%% @spec dump() -> {mochiweb_request, [{atom(), term()}]}
+%% @spec dump(request()) -> {mochiweb_request, [{atom(), term()}]}
 %% @doc Dump the internal representation to a "human readable" set of terms
 %%      for debugging/inspection purposes.
-dump() ->
+dump({?MODULE, [_Socket, Method, RawPath, Version, Headers]}) ->
     {?MODULE, [{method, Method},
                {version, Version},
                {raw_path, RawPath},
                {headers, mochiweb_headers:to_list(Headers)}]}.
 
-%% @spec send(iodata()) -> ok
+%% @spec send(iodata(), request()) -> ok
 %% @doc Send data over the socket.
-send(Data) ->
+send(Data, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     case mochiweb_socket:send(Socket, Data) of
         ok ->
             ok;
@@ -146,16 +153,16 @@ send(Data) ->
             exit(normal)
     end.
 
-%% @spec recv(integer()) -> binary()
+%% @spec recv(integer(), request()) -> binary()
 %% @doc Receive Length bytes from the client as a binary, with the default
 %%      idle timeout.
-recv(Length) ->
-    recv(Length, ?IDLE_TIMEOUT).
+recv(Length, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    recv(Length, ?IDLE_TIMEOUT, THIS).
 
-%% @spec recv(integer(), integer()) -> binary()
+%% @spec recv(integer(), integer(), request()) -> binary()
 %% @doc Receive Length bytes from the client as a binary, with the given
 %%      Timeout in msec.
-recv(Length, Timeout) ->
+recv(Length, Timeout, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     case mochiweb_socket:recv(Socket, Length, Timeout) of
         {ok, Data} ->
             put(?SAVE_RECV, true),
@@ -164,12 +171,12 @@ recv(Length, Timeout) ->
             exit(normal)
     end.
 
-%% @spec body_length() -> undefined | chunked | unknown_transfer_encoding | integer()
+%% @spec body_length(request()) -> undefined | chunked | unknown_transfer_encoding | integer()
 %% @doc  Infer body length from transfer-encoding and content-length headers.
-body_length() ->
-    case get_header_value("transfer-encoding") of
+body_length({?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    case get_header_value("transfer-encoding", THIS) of
         undefined ->
-            case get_header_value("content-length") of
+            case get_header_value("content-length", THIS) of
                 undefined ->
                     undefined;
                 Length ->
@@ -182,16 +189,16 @@ body_length() ->
     end.
 
 
-%% @spec recv_body() -> binary()
+%% @spec recv_body(request()) -> binary()
 %% @doc Receive the body of the HTTP request (defined by Content-Length).
 %%      Will only receive up to the default max-body length of 1MB.
-recv_body() ->
-    recv_body(?MAX_RECV_BODY).
+recv_body({?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    recv_body(?MAX_RECV_BODY, THIS).
 
-%% @spec recv_body(integer()) -> binary()
+%% @spec recv_body(integer(), request()) -> binary()
 %% @doc Receive the body of the HTTP request (defined by Content-Length).
 %%      Will receive up to MaxBody bytes.
-recv_body(MaxBody) ->
+recv_body(MaxBody, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case erlang:get(?SAVE_BODY) of
         undefined ->
             % we could use a sane constant for max chunk size
@@ -205,17 +212,19 @@ recv_body(MaxBody) ->
                     true ->
                         {NewLength, [Bin | BinAcc]}
                     end
-                end, {0, []}, MaxBody),
+                end, {0, []}, MaxBody, THIS),
             put(?SAVE_BODY, Body),
             Body;
         Cached -> Cached
     end.
 
-stream_body(MaxChunkSize, ChunkFun, FunState) ->
-    stream_body(MaxChunkSize, ChunkFun, FunState, undefined).
+stream_body(MaxChunkSize, ChunkFun, FunState,
+            {?MODULE,[_Socket,_Method,_RawPath,_Version,_Headers]}=THIS) ->
+    stream_body(MaxChunkSize, ChunkFun, FunState, undefined, THIS).
 
-stream_body(MaxChunkSize, ChunkFun, FunState, MaxBodyLength) ->
-    Expect = case get_header_value("expect") of
+stream_body(MaxChunkSize, ChunkFun, FunState, MaxBodyLength,
+            {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    Expect = case get_header_value("expect", THIS) of
                  undefined ->
                      undefined;
                  Value when is_list(Value) ->
@@ -223,11 +232,11 @@ stream_body(MaxChunkSize, ChunkFun, FunState, MaxBodyLength) ->
              end,
     case Expect of
         "100-continue" ->
-            start_raw_response({100, gb_trees:empty()});
+            start_raw_response({100, gb_trees:empty()}, THIS);
         _Else ->
             ok
     end,
-    case body_length() of
+    case body_length(THIS) of
         undefined ->
             undefined;
         {unknown_transfer_encoding, Unknown} ->
@@ -236,7 +245,7 @@ stream_body(MaxChunkSize, ChunkFun, FunState, MaxBodyLength) ->
             % In this case the MaxBody is actually used to
             % determine the maximum allowed size of a single
             % chunk.
-            stream_chunked_body(MaxChunkSize, ChunkFun, FunState);
+            stream_chunked_body(MaxChunkSize, ChunkFun, FunState, THIS);
         0 ->
             <<>>;
         Length when is_integer(Length) ->
@@ -244,60 +253,64 @@ stream_body(MaxChunkSize, ChunkFun, FunState, MaxBodyLength) ->
             MaxBodyLength when is_integer(MaxBodyLength), MaxBodyLength < Length ->
                 exit({body_too_large, content_length});
             _ ->
-                stream_unchunked_body(Length, ChunkFun, FunState)
+                stream_unchunked_body(Length, ChunkFun, FunState, THIS)
             end
     end.
 
 
-%% @spec start_response({integer(), ioheaders()}) -> response()
+%% @spec start_response({integer(), ioheaders()}, request()) -> response()
 %% @doc Start the HTTP response by sending the Code HTTP response and
 %%      ResponseHeaders. The server will set header defaults such as Server
 %%      and Date if not present in ResponseHeaders.
-start_response({Code, ResponseHeaders}) ->
+start_response({Code, ResponseHeaders},
+               {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     HResponse = mochiweb_headers:make(ResponseHeaders),
     HResponse1 = mochiweb_headers:default_from_list(server_headers(),
                                                     HResponse),
-    start_raw_response({Code, HResponse1}).
+    start_raw_response({Code, HResponse1}, THIS).
 
-%% @spec start_raw_response({integer(), headers()}) -> response()
+%% @spec start_raw_response({integer(), headers()}, request()) -> response()
 %% @doc Start the HTTP response by sending the Code HTTP response and
 %%      ResponseHeaders.
-start_raw_response({Code, ResponseHeaders}) ->
+start_raw_response({Code, ResponseHeaders},
+                   {?MODULE, [_Socket, _Method, _RawPath, Version, _Headers]}=THIS) ->
     F = fun ({K, V}, Acc) ->
                 [mochiweb_util:make_io(K), <<": ">>, V, <<"\r\n">> | Acc]
         end,
     End = lists:foldl(F, [<<"\r\n">>],
                       mochiweb_headers:to_list(ResponseHeaders)),
-    send([make_version(Version), make_code(Code), <<"\r\n">> | End]),
+    send([make_version(Version), make_code(Code), <<"\r\n">> | End], THIS),
     mochiweb:new_response({THIS, Code, ResponseHeaders}).
 
-
-%% @spec start_response_length({integer(), ioheaders(), integer()}) -> response()
+%% @spec start_response_length({integer(), ioheaders(), integer()}, request()) -> response()
 %% @doc Start the HTTP response by sending the Code HTTP response and
 %%      ResponseHeaders including a Content-Length of Length. The server
 %%      will set header defaults such as Server
 %%      and Date if not present in ResponseHeaders.
-start_response_length({Code, ResponseHeaders, Length}) ->
+start_response_length({Code, ResponseHeaders, Length},
+                      {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     HResponse = mochiweb_headers:make(ResponseHeaders),
     HResponse1 = mochiweb_headers:enter("Content-Length", Length, HResponse),
-    start_response({Code, HResponse1}).
+    start_response({Code, HResponse1}, THIS).
 
-%% @spec respond({integer(), ioheaders(), iodata() | chunked | {file, IoDevice}}) -> response()
+%% @spec respond({integer(), ioheaders(), iodata() | chunked | {file, IoDevice}}, request()) -> response()
 %% @doc Start the HTTP response with start_response, and send Body to the
 %%      client (if the get(method) /= 'HEAD'). The Content-Length header
 %%      will be set by the Body length, and the server will insert header
 %%      defaults.
-respond({Code, ResponseHeaders, {file, IoDevice}}) ->
+respond({Code, ResponseHeaders, {file, IoDevice}},
+        {?MODULE, [_Socket, Method, _RawPath, _Version, _Headers]}=THIS) ->
     Length = mochiweb_io:iodevice_size(IoDevice),
-    Response = start_response_length({Code, ResponseHeaders, Length}),
+    Response = start_response_length({Code, ResponseHeaders, Length}, THIS),
     case Method of
         'HEAD' ->
             ok;
         _ ->
-            mochiweb_io:iodevice_stream(fun send/1, IoDevice)
+            mochiweb_io:iodevice_stream(fun send/2, IoDevice)
     end,
     Response;
-respond({Code, ResponseHeaders, chunked}) ->
+respond({Code, ResponseHeaders, chunked},
+        {?MODULE, [_Socket, Method, _RawPath, Version, _Headers]}=THIS) ->
     HResponse = mochiweb_headers:make(ResponseHeaders),
     HResponse1 = case Method of
                      'HEAD' ->
@@ -318,35 +331,38 @@ respond({Code, ResponseHeaders, chunked}) ->
                          put(?SAVE_FORCE_CLOSE, true),
                          HResponse
                  end,
-    start_response({Code, HResponse1});
-respond({Code, ResponseHeaders, Body}) ->
-    Response = start_response_length({Code, ResponseHeaders, iolist_size(Body)}),
+    start_response({Code, HResponse1}, THIS);
+respond({Code, ResponseHeaders, Body},
+        {?MODULE, [_Socket, Method, _RawPath, _Version, _Headers]}=THIS) ->
+    Response = start_response_length({Code, ResponseHeaders, iolist_size(Body)}, THIS),
     case Method of
         'HEAD' ->
             ok;
         _ ->
-            send(Body)
+            send(Body, THIS)
     end,
     Response.
 
-%% @spec not_found() -> response()
+%% @spec not_found(request()) -> response()
 %% @doc Alias for <code>not_found([])</code>.
-not_found() ->
-    not_found([]).
+not_found({?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    not_found([], THIS).
 
-%% @spec not_found(ExtraHeaders) -> response()
+%% @spec not_found(ExtraHeaders, request()) -> response()
 %% @doc Alias for <code>respond({404, [{"Content-Type", "text/plain"}
 %% | ExtraHeaders], &lt;&lt;"Not found."&gt;&gt;})</code>.
-not_found(ExtraHeaders) ->
+not_found(ExtraHeaders, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     respond({404, [{"Content-Type", "text/plain"} | ExtraHeaders],
-             <<"Not found.">>}).
+             <<"Not found.">>}, THIS).
 
-%% @spec ok({value(), iodata()} | {value(), ioheaders(), iodata() | {file, IoDevice}}) ->
+%% @spec ok({value(), iodata()} | {value(), ioheaders(), iodata() | {file, IoDevice}}, request()) ->
 %%           response()
 %% @doc respond({200, [{"Content-Type", ContentType} | Headers], Body}).
-ok({ContentType, Body}) ->
-    ok({ContentType, [], Body});
-ok({ContentType, ResponseHeaders, Body}) ->
+ok({ContentType, Body},
+   {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    ok({ContentType, [], Body}, THIS);
+ok({ContentType, ResponseHeaders, Body},
+   {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     HResponse = mochiweb_headers:make(ResponseHeaders),
     case THIS:get(range) of
         X when (X =:= undefined orelse X =:= fail) orelse Body =:= chunked ->
@@ -355,7 +371,7 @@ ok({ContentType, ResponseHeaders, Body}) ->
             %% full response.
             HResponse1 = mochiweb_headers:enter("Content-Type", ContentType,
                                                 HResponse),
-            respond({200, HResponse1, Body});
+            respond({200, HResponse1, Body}, THIS);
         Ranges ->
             {PartList, Size} = range_parts(Body, Ranges),
             case PartList of
@@ -364,7 +380,7 @@ ok({ContentType, ResponseHeaders, Body}) ->
                                                         ContentType,
                                                         HResponse),
                     %% could be 416, for now we'll just return 200
-                    respond({200, HResponse1, Body});
+                    respond({200, HResponse1, Body}, THIS);
                 PartList ->
                     {RangeHeaders, RangeBody} =
                         mochiweb_multipart:parts_to_body(PartList, ContentType, Size),
@@ -372,33 +388,33 @@ ok({ContentType, ResponseHeaders, Body}) ->
                                    [{"Accept-Ranges", "bytes"} |
                                     RangeHeaders],
                                    HResponse),
-                    respond({206, HResponse1, RangeBody})
+                    respond({206, HResponse1, RangeBody}, THIS)
             end
     end.
 
-%% @spec should_close() -> bool()
+%% @spec should_close(request()) -> bool()
 %% @doc Return true if the connection must be closed. If false, using
 %%      Keep-Alive should be safe.
-should_close() ->
+should_close({?MODULE, [_Socket, _Method, _RawPath, Version, _Headers]}=THIS) ->
     ForceClose = erlang:get(?SAVE_FORCE_CLOSE) =/= undefined,
     DidNotRecv = erlang:get(?SAVE_RECV) =:= undefined,
     ForceClose orelse Version < {1, 0}
         %% Connection: close
-        orelse get_header_value("connection") =:= "close"
+        orelse get_header_value("connection", THIS) =:= "close"
         %% HTTP 1.0 requires Connection: Keep-Alive
         orelse (Version =:= {1, 0}
-                andalso get_header_value("connection") =/= "Keep-Alive")
+                andalso get_header_value("connection", THIS) =/= "Keep-Alive")
         %% unread data left on the socket, can't safely continue
         orelse (DidNotRecv
-                andalso get_header_value("content-length") =/= undefined
-                andalso list_to_integer(get_header_value("content-length")) > 0)
+                andalso get_header_value("content-length", THIS) =/= undefined
+                andalso list_to_integer(get_header_value("content-length", THIS)) > 0)
         orelse (DidNotRecv
-                andalso get_header_value("transfer-encoding") =:= "chunked").
+                andalso get_header_value("transfer-encoding", THIS) =:= "chunked").
 
-%% @spec cleanup() -> ok
+%% @spec cleanup(request()) -> ok
 %% @doc Clean up any junk in the process dictionary, required before continuing
 %%      a Keep-Alive request.
-cleanup() ->
+cleanup({?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}) ->
     [erase(K) || K <- [?SAVE_QS,
                        ?SAVE_PATH,
                        ?SAVE_RECV,
@@ -409,9 +425,9 @@ cleanup() ->
                        ?SAVE_FORCE_CLOSE]],
     ok.
 
-%% @spec parse_qs() -> [{Key::string(), Value::string()}]
+%% @spec parse_qs(request()) -> [{Key::string(), Value::string()}]
 %% @doc Parse the query string of the URL.
-parse_qs() ->
+parse_qs({?MODULE, [_Socket, _Method, RawPath, _Version, _Headers]}) ->
     case erlang:get(?SAVE_QS) of
         undefined ->
             {_, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
@@ -422,17 +438,17 @@ parse_qs() ->
             Cached
     end.
 
-%% @spec get_cookie_value(Key::string) -> string() | undefined
+%% @spec get_cookie_value(Key::string, request()) -> string() | undefined
 %% @doc Get the value of the given cookie.
-get_cookie_value(Key) ->
-    proplists:get_value(Key, parse_cookie()).
+get_cookie_value(Key, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    proplists:get_value(Key, parse_cookie(THIS)).
 
-%% @spec parse_cookie() -> [{Key::string(), Value::string()}]
+%% @spec parse_cookie(request()) -> [{Key::string(), Value::string()}]
 %% @doc Parse the cookie header.
-parse_cookie() ->
+parse_cookie({?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case erlang:get(?SAVE_COOKIE) of
         undefined ->
-            Cookies = case get_header_value("cookie") of
+            Cookies = case get_header_value("cookie", THIS) of
                           undefined ->
                               [];
                           Value ->
@@ -444,17 +460,17 @@ parse_cookie() ->
             Cached
     end.
 
-%% @spec parse_post() -> [{Key::string(), Value::string()}]
+%% @spec parse_post(request()) -> [{Key::string(), Value::string()}]
 %% @doc Parse an application/x-www-form-urlencoded form POST. This
 %%      has the side-effect of calling recv_body().
-parse_post() ->
+parse_post({?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case erlang:get(?SAVE_POST) of
         undefined ->
-            Parsed = case recv_body() of
+            Parsed = case recv_body(THIS) of
                          undefined ->
                              [];
                          Binary ->
-                             case get_primary_header_value("content-type") of
+                             case get_primary_header_value("content-type", THIS) of
                                  "application/x-www-form-urlencoded" ++ _ ->
                                      mochiweb_util:parse_qs(Binary);
                                  _ ->
@@ -467,37 +483,40 @@ parse_post() ->
             Cached
     end.
 
-%% @spec stream_chunked_body(integer(), fun(), term()) -> term()
+%% @spec stream_chunked_body(integer(), fun(), term(), request()) -> term()
 %% @doc The function is called for each chunk.
 %%      Used internally by read_chunked_body.
-stream_chunked_body(MaxChunkSize, Fun, FunState) ->
-    case read_chunk_length() of
+stream_chunked_body(MaxChunkSize, Fun, FunState,
+                    {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    case read_chunk_length(THIS) of
         0 ->
-            Fun({0, read_chunk(0)}, FunState);
+            Fun({0, read_chunk(0, THIS)}, FunState);
         Length when Length > MaxChunkSize ->
-            NewState = read_sub_chunks(Length, MaxChunkSize, Fun, FunState),
-            stream_chunked_body(MaxChunkSize, Fun, NewState);
+            NewState = read_sub_chunks(Length, MaxChunkSize, Fun, FunState, THIS),
+            stream_chunked_body(MaxChunkSize, Fun, NewState, THIS);
         Length ->
-            NewState = Fun({Length, read_chunk(Length)}, FunState),
-            stream_chunked_body(MaxChunkSize, Fun, NewState)
+            NewState = Fun({Length, read_chunk(Length, THIS)}, FunState),
+            stream_chunked_body(MaxChunkSize, Fun, NewState, THIS)
     end.
 
-stream_unchunked_body(0, Fun, FunState) ->
+stream_unchunked_body(0, Fun, FunState,
+                      {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}) ->
     Fun({0, <<>>}, FunState);
-stream_unchunked_body(Length, Fun, FunState) when Length > 0 ->
+stream_unchunked_body(Length, Fun, FunState,
+                      {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) when Length > 0 ->
     PktSize = case Length > ?RECBUF_SIZE of
         true ->
             ?RECBUF_SIZE;
         false ->
             Length
     end,
-    Bin = recv(PktSize),
+    Bin = recv(PktSize, THIS),
     NewState = Fun({PktSize, Bin}, FunState),
-    stream_unchunked_body(Length - PktSize, Fun, NewState).
+    stream_unchunked_body(Length - PktSize, Fun, NewState, THIS).
 
-%% @spec read_chunk_length() -> integer()
+%% @spec read_chunk_length(request()) -> integer()
 %% @doc Read the length of the next HTTP chunk.
-read_chunk_length() ->
+read_chunk_length({?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     mochiweb_socket:setopts(Socket, [{packet, line}]),
     case mochiweb_socket:recv(Socket, 0, ?IDLE_TIMEOUT) of
         {ok, Header} ->
@@ -511,10 +530,10 @@ read_chunk_length() ->
             exit(normal)
     end.
 
-%% @spec read_chunk(integer()) -> Chunk::binary() | [Footer::binary()]
+%% @spec read_chunk(integer(), request()) -> Chunk::binary() | [Footer::binary()]
 %% @doc Read in a HTTP chunk of the given length. If Length is 0, then read the
 %%      HTTP footers (as a list of binaries, since they're nominal).
-read_chunk(0) ->
+read_chunk(0, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     mochiweb_socket:setopts(Socket, [{packet, line}]),
     F = fun (F1, Acc) ->
                 case mochiweb_socket:recv(Socket, 0, ?IDLE_TIMEOUT) of
@@ -530,7 +549,7 @@ read_chunk(0) ->
     mochiweb_socket:setopts(Socket, [{packet, raw}]),
     put(?SAVE_RECV, true),
     Footers;
-read_chunk(Length) ->
+read_chunk(Length, {?MODULE, [Socket, _Method, _RawPath, _Version, _Headers]}) ->
     case mochiweb_socket:recv(Socket, 2 + Length, ?IDLE_TIMEOUT) of
         {ok, <<Chunk:Length/binary, "\r\n">>} ->
             Chunk;
@@ -538,22 +557,25 @@ read_chunk(Length) ->
             exit(normal)
     end.
 
-read_sub_chunks(Length, MaxChunkSize, Fun, FunState) when Length > MaxChunkSize ->
-    Bin = recv(MaxChunkSize),
+read_sub_chunks(Length, MaxChunkSize, Fun, FunState,
+                {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) when Length > MaxChunkSize ->
+    Bin = recv(MaxChunkSize, THIS),
     NewState = Fun({size(Bin), Bin}, FunState),
-    read_sub_chunks(Length - MaxChunkSize, MaxChunkSize, Fun, NewState);
+    read_sub_chunks(Length - MaxChunkSize, MaxChunkSize, Fun, NewState, THIS);
 
-read_sub_chunks(Length, _MaxChunkSize, Fun, FunState) ->
-    Fun({Length, read_chunk(Length)}, FunState).
+read_sub_chunks(Length, _MaxChunkSize, Fun, FunState,
+                {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    Fun({Length, read_chunk(Length, THIS)}, FunState).
 
-%% @spec serve_file(Path, DocRoot) -> Response
+%% @spec serve_file(Path, DocRoot, request()) -> Response
 %% @doc Serve a file relative to DocRoot.
-serve_file(Path, DocRoot) ->
-    serve_file(Path, DocRoot, []).
+serve_file(Path, DocRoot, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    serve_file(Path, DocRoot, [], THIS).
 
-%% @spec serve_file(Path, DocRoot, ExtraHeaders) -> Response
+%% @spec serve_file(Path, DocRoot, ExtraHeaders, request()) -> Response
 %% @doc Serve a file relative to DocRoot.
-serve_file(Path, DocRoot, ExtraHeaders) ->
+serve_file(Path, DocRoot, ExtraHeaders,
+           {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case mochiweb_util:safe_relative_path(Path) of
         undefined ->
             not_found(ExtraHeaders);
@@ -561,9 +583,9 @@ serve_file(Path, DocRoot, ExtraHeaders) ->
             FullPath = filename:join([DocRoot, RelPath]),
             case filelib:is_dir(FullPath) of
                 true ->
-                    maybe_redirect(RelPath, FullPath, ExtraHeaders);
+                    maybe_redirect(RelPath, FullPath, ExtraHeaders, THIS);
                 false ->
-                    maybe_serve_file(FullPath, ExtraHeaders)
+                    maybe_serve_file(FullPath, ExtraHeaders, THIS)
             end
     end.
 
@@ -573,13 +595,15 @@ serve_file(Path, DocRoot, ExtraHeaders) ->
 directory_index(FullPath) ->
     filename:join([FullPath, "index.html"]).
 
-maybe_redirect([], FullPath, ExtraHeaders) ->
-    maybe_serve_file(directory_index(FullPath), ExtraHeaders);
+maybe_redirect([], FullPath, ExtraHeaders,
+               {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    maybe_serve_file(directory_index(FullPath), ExtraHeaders, THIS);
 
-maybe_redirect(RelPath, FullPath, ExtraHeaders) ->
+maybe_redirect(RelPath, FullPath, ExtraHeaders,
+               {?MODULE, [_Socket, _Method, _RawPath, _Version, Headers]}=THIS) ->
     case string:right(RelPath, 1) of
         "/" ->
-            maybe_serve_file(directory_index(FullPath), ExtraHeaders);
+            maybe_serve_file(directory_index(FullPath), ExtraHeaders, THIS);
         _   ->
             Host = mochiweb_headers:get_value("host", Headers),
             Location = "http://" ++ Host  ++ "/" ++ RelPath ++ "/",
@@ -594,16 +618,17 @@ maybe_redirect(RelPath, FullPath, ExtraHeaders) ->
             "<p>The document has moved <a href=\"">>,
             Bottom = <<">here</a>.</p></body></html>\n">>,
             Body = <<Top/binary, LocationBin/binary, Bottom/binary>>,
-            respond({301, MoreHeaders, Body})
+            respond({301, MoreHeaders, Body}, THIS)
     end.
 
-maybe_serve_file(File, ExtraHeaders) ->
+maybe_serve_file(File, ExtraHeaders,
+                 {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     case file:read_file_info(File) of
         {ok, FileInfo} ->
             LastModified = httpd_util:rfc1123_date(FileInfo#file_info.mtime),
-            case get_header_value("if-modified-since") of
+            case get_header_value("if-modified-since", THIS) of
                 LastModified ->
-                    respond({304, ExtraHeaders, ""});
+                    respond({304, ExtraHeaders, ""}, THIS);
                 _ ->
                     case file:open(File, [raw, binary]) of
                         {ok, IoDevice} ->
@@ -611,15 +636,15 @@ maybe_serve_file(File, ExtraHeaders) ->
                             Res = ok({ContentType,
                                       [{"last-modified", LastModified}
                                        | ExtraHeaders],
-                                      {file, IoDevice}}),
+                                      {file, IoDevice}}, THIS),
                             file:close(IoDevice),
                             Res;
                         _ ->
-                            not_found(ExtraHeaders)
+                            not_found(ExtraHeaders, THIS)
                     end
             end;
         {error, _} ->
-            not_found(ExtraHeaders)
+            not_found(ExtraHeaders, THIS)
     end.
 
 server_headers() ->
@@ -667,7 +692,7 @@ range_parts(Body0, Ranges) ->
         end,
     {lists:foldr(F, [], Ranges), Size}.
 
-%% @spec accepted_encodings([encoding()]) -> [encoding()] | bad_accept_encoding_value
+%% @spec accepted_encodings([encoding()], request()) -> [encoding()] | bad_accept_encoding_value
 %% @type encoding() = string().
 %%
 %% @doc Returns a list of encodings accepted by a request. Encodings that are
@@ -691,8 +716,8 @@ range_parts(Body0, Ranges) ->
 %%         accepted_encodings(["gzip", "deflate", "identity"]) ->
 %%            ["deflate", "gzip", "identity"]
 %%
-accepted_encodings(SupportedEncodings) ->
-    AcceptEncodingHeader = case get_header_value("Accept-Encoding") of
+accepted_encodings(SupportedEncodings, {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
+    AcceptEncodingHeader = case get_header_value("Accept-Encoding", THIS) of
         undefined ->
             "";
         Value ->
@@ -707,7 +732,7 @@ accepted_encodings(SupportedEncodings) ->
             )
     end.
 
-%% @spec accepts_content_type(string() | binary()) -> boolean() | bad_accept_header
+%% @spec accepts_content_type(string() | binary(), request()) -> boolean() | bad_accept_header
 %%
 %% @doc Determines whether a request accepts a given media type by analyzing its
 %%      "Accept" header.
@@ -729,11 +754,13 @@ accepted_encodings(SupportedEncodings) ->
 %%      5) For an "Accept" header with value "text/*; q=0.0, */*":
 %%         accepts_content_type("text/plain") -> false
 %%
-accepts_content_type(ContentType) when is_binary(ContentType) ->
-    accepts_content_type(binary_to_list(ContentType));
-accepts_content_type(ContentType1) ->
+accepts_content_type(ContentType,
+                     {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) when is_binary(ContentType) ->
+    accepts_content_type(binary_to_list(ContentType), THIS);
+accepts_content_type(ContentType1,
+                     {?MODULE, [_Socket, _Method, _RawPath, _Version, _Headers]}=THIS) ->
     ContentType = re:replace(ContentType1, "\\s", "", [global, {return, list}]),
-    AcceptHeader = case get_header_value("Accept") of
+    AcceptHeader = case get_header_value("Accept", THIS) of
         undefined ->
             "*/*";
         Value ->

--- a/src/mochiweb_response.erl
+++ b/src/mochiweb_response.erl
@@ -3,39 +3,46 @@
 
 %% @doc Response abstraction.
 
--module(mochiweb_response, [Request, Code, Headers]).
+-module(mochiweb_response).
 -author('bob@mochimedia.com').
 
 -define(QUIP, "Any of you quaids got a smint?").
 
--export([get_header_value/1, get/1, dump/0]).
--export([send/1, write_chunk/1]).
+-export([new/3, get_header_value/2, get/2, dump/1]).
+-export([send/2, write_chunk/2]).
 
-%% @spec get_header_value(string() | atom() | binary()) -> string() | undefined
+%% @type response(). A mochiweb_response parameterized module instance.
+
+%% @spec new(Request, Code, Headers) -> response()
+%% @doc Create a new mochiweb_response instance.
+new(Request, Code, Headers) ->
+    {?MODULE, [Request, Code, Headers]}.
+
+%% @spec get_header_value(string() | atom() | binary(), response()) -> string() | undefined
 %% @doc Get the value of the given response header.
-get_header_value(K) ->
+get_header_value(K, {?MODULE, [_Request, _Code, Headers]}) ->
     mochiweb_headers:get_value(K, Headers).
 
-%% @spec get(request | code | headers) -> term()
+%% @spec get(request | code | headers, response()) -> term()
 %% @doc Return the internal representation of the given field.
-get(request) ->
+get(request, {?MODULE, [Request, _Code, _Headers]}) ->
     Request;
-get(code) ->
+get(code, {?MODULE, [_Request, Code, _Headers]}) ->
     Code;
-get(headers) ->
+get(headers, {?MODULE, [_Request, _Code, Headers]}) ->
     Headers.
 
-%% @spec dump() -> {mochiweb_request, [{atom(), term()}]}
+%% @spec dump(response()) -> {mochiweb_request, [{atom(), term()}]}
 %% @doc Dump the internal representation to a "human readable" set of terms
 %%      for debugging/inspection purposes.
-dump() ->
+dump({?MODULE, [Request, Code, Headers]}) ->
     [{request, Request:dump()},
      {code, Code},
      {headers, mochiweb_headers:to_list(Headers)}].
 
-%% @spec send(iodata()) -> ok
+%% @spec send(iodata(), response()) -> ok
 %% @doc Send data over the socket if the method is not HEAD.
-send(Data) ->
+send(Data, {?MODULE, [Request, _Code, _Headers]}) ->
     case Request:get(method) of
         'HEAD' ->
             ok;
@@ -43,16 +50,16 @@ send(Data) ->
             Request:send(Data)
     end.
 
-%% @spec write_chunk(iodata()) -> ok
+%% @spec write_chunk(iodata(), response()) -> ok
 %% @doc Write a chunk of a HTTP chunked response. If Data is zero length,
 %%      then the chunked response will be finished.
-write_chunk(Data) ->
+write_chunk(Data, {?MODULE, [Request, _Code, _Headers]}=THIS) ->
     case Request:get(version) of
         Version when Version >= {1, 1} ->
             Length = iolist_size(Data),
-            send([io_lib:format("~.16b\r\n", [Length]), Data, <<"\r\n">>]);
+            send([io_lib:format("~.16b\r\n", [Length]), Data, <<"\r\n">>], THIS);
         _ ->
-            send(Data)
+            send(Data, THIS)
     end.
 
 


### PR DESCRIPTION
Backport mochiweb changes from master to deprecate parameterized modules in mochiweb 1.5.
