### PR TITLE
Fix for Erlang R16B01

### DIFF
--- a/src/mochiweb_socket_server.erl
+++ b/src/mochiweb_socket_server.erl
@@ -141,6 +141,7 @@ start_server(F, State=#mochiweb_socket_server{ssl=Ssl, name=Name}) ->
 
 prep_ssl(true) ->
     ok = mochiweb:ensure_started(crypto),
+    ok = mochiweb:ensure_started(asn1),
     ok = mochiweb:ensure_started(public_key),
     ok = mochiweb:ensure_started(ssl);
 prep_ssl(false) ->


### PR DESCRIPTION
Cherry-picked this commit from mochi/mochiweb; it's needed because as of Erlang/OTP R16 the `public_key` app required for SSL connections depends on the `asn1` app, which wasn't being started. Mochiweb unit tests also fail under R16B+ without this commit.
