### PR TITLE
start asn1 app if ssl is used

### DIFF
--- a/src/mochiweb_socket_server.erl
+++ b/src/mochiweb_socket_server.erl
@@ -120,6 +120,7 @@ start_server(State=#mochiweb_socket_server{ssl=Ssl, name=Name}) ->
     case Ssl of
         true ->
             application:start(crypto),
+            application:start(asn1),
             application:start(public_key),
             application:start(ssl);
         false ->


### PR DESCRIPTION
The ssl app has asn1 as a dependency in R16B01+. Make sure asn1 is started if ssl is used. Similar to commit d83ed7fb but backported to 1.5.

This fixes mochiweb eunit failures when it's tested as a dependency in the riak repo.
