### PR TITLE
Prevent mochiweb from returning a spurious 400 response

### DIFF
--- a/test/mochiweb_http_tests.erl
+++ b/test/mochiweb_http_tests.erl
@@ -1,0 +1,91 @@
+%% Backport of mochiweb_http_tests to earlier version.  This will cause forward merge conflicts.
+-module(mochiweb_http_tests).
+-include_lib("eunit/include/eunit.hrl").
+-ifdef(gen_tcp_r15b_workaround).
+-define(SHOULD_HAVE_BUG, true).
+-else.
+-define(SHOULD_HAVE_BUG, false).
+-endif.
+
+has_acceptor_bug_test_() ->
+    {setup,
+     fun start_server/0,
+     fun mochiweb_http:stop/1,
+     fun has_acceptor_bug_tests/1}.
+
+unexpected_msg_test_() ->
+    {setup,
+     fun start_server/0,
+     fun mochiweb_http:stop/1,
+     fun unexpected_msg_in_hdr_tests/1}.
+
+start_server() ->
+    application:start(inets),
+    {ok, Pid} = mochiweb_http:start([{port, 0},
+				     {acceptor_pool_size,1},
+				     {loop, fun responder/1}]),
+    Pid.
+
+has_acceptor_bug_tests(Server) ->
+    Port = mochiweb_socket_server:get(Server, port),
+    [{"1000 should be fine even with the bug",
+      ?_assertEqual(false, has_bug(Port, 1000))},
+     {"10000 should trigger the bug if present",
+      ?_assertEqual(?SHOULD_HAVE_BUG, has_bug(Port, 10000))}].
+
+responder(Req) ->
+    Req:respond({200,
+                 [{"Content-Type", "text/html"}],
+                 ["<html><body>Hello</body></html>"]}).
+
+has_bug(Port, Len) ->
+  case
+    httpc:request(get, {"http://127.0.0.1:" ++ integer_to_list(Port) ++ "/",
+                        [{"X-Random", lists:duplicate(Len, $a)}]}, [], [])
+  of
+      {error, socket_closed_remotely} ->
+          true;
+      {ok, {{"HTTP/1.1", 200, "OK"}, _, "<html><body>Hello</body></html>"}} ->
+          false;
+      {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, []}} ->
+          false
+  end.
+
+
+-define(IN_METHOD, 3). % The space after the get.
+-define(IN_HEADER, 20). % The dash after user
+get_req() ->
+    <<"GET / HTTP/1.1\r\n"
+      "User-Agent: mochiweb_http_tests/0.0\r\n"
+      "Accept: */*\r\n\r\n">>.
+
+unexpected_msg(Server, MsgAt, Msg) ->
+    %% Set up with a single acceptor, dig out the pid - sensitive to change in mochiweb_socket_server
+    %% state record.
+    [Acceptor] = sets:to_list(element(14, sys:get_state(Server))),
+    Port = mochiweb_socket_server:get(Server, port),
+    <<Before:MsgAt/binary, After/binary>> = get_req(),
+    {ok, S} = gen_tcp:connect({127,0,0,1},Port,[binary,{active,false}]),
+    ok = gen_tcp:send(S, Before),
+    Acceptor ! Msg,
+    gen_tcp:send(S, After),
+    gen_tcp:recv(S, 0, 5000).
+    
+
+unexpected_msg_in_hdr_tests(Server) ->
+    [{"should ignore a message in the middle of the request line",
+      ?_assertMatch({ok, <<"HTTP/1.1 200 OK", _Rest/binary>>},
+		    unexpected_msg(Server, ?IN_METHOD, unexpected_msg_in_your_method))},
+     {"should ignore a message in the middle of a header",
+      ?_assertMatch({ok, <<"HTTP/1.1 200 OK", _Rest/binary>>},
+		    unexpected_msg(Server, ?IN_HEADER, unexpected_msg_in_your_header))},
+     {"should close on a TCP error on the request line",
+      ?_assertMatch({error, closed},
+		    unexpected_msg(Server, ?IN_METHOD, {tcp_error, your_port_you_dont_match_on, something_terrible}))},
+     {"should close on a TCP error in a header",
+      ?_assertMatch({error, closed},
+		    unexpected_msg(Server, ?IN_HEADER, {tcp_error, your_port_you_dont_match_on, something_terrible}))}].
+
+
+
+


### PR DESCRIPTION
This patch prevents mochiweb from returning an erroneous 400 response when a garbage message is sent to the socket acceptor's mailbox. 

Original patch: https://github.com/eriksoe/mochiweb/commit/a529fd4509e46471df79e4ec6bc7e2e421bb1bd4